### PR TITLE
handle exception if a document is intended to be inserted into an edg…

### DIFF
--- a/src/main/java/org/humanbrainproject/knowledgegraph/commons/propertyGraph/arango/control/ArangoTransaction.java
+++ b/src/main/java/org/humanbrainproject/knowledgegraph/commons/propertyGraph/arango/control/ArangoTransaction.java
@@ -91,6 +91,11 @@ public class ArangoTransaction implements DatabaseTransaction {
                     }
                 }
                 else {
+                    ArangoCollection targetCollection = databaseConnection.getOrCreateDB().collection(reference.getCollection().getName());
+                    if(targetCollection.exists() && targetCollection.getInfo().getType() == CollectionType.EDGES){
+                        logger.error(String.format("Tried to insert a document into an edge collection (%s). This has to be an invalid payload (maybe the document was not properly defined to be a linking instance)", reference.getCollection().getName()));
+                        break;
+                    }
                     //Remove already existing instances
                     deleteOutgoingRelations(reference, databaseConnection);
                     deleteDocument(reference, database);

--- a/src/main/java/org/humanbrainproject/knowledgegraph/indexing/boundary/GraphIndexing.java
+++ b/src/main/java/org/humanbrainproject/knowledgegraph/indexing/boundary/GraphIndexing.java
@@ -63,7 +63,6 @@ public class GraphIndexing {
             for (IndexingController indexingController : getIndexingControllers()) {
                 indexingController.insert(qualifiedSpec, todoList);
             }
-
             //Execute
             transaction.execute(todoList);
         } else {


### PR DESCRIPTION
…e collection. This is obviously an error but can be caused by errorenous payloads (e.g. a missing LinkingInstance type). We log the error and continue.